### PR TITLE
Offload "full" Sinkhorn application

### DIFF
--- a/hammerblade/torch/tests/sinkhorn_tests/sinkhorn_app/profiling_kernels/test_sinkhorn_simple.py
+++ b/hammerblade/torch/tests/sinkhorn_tests/sinkhorn_app/profiling_kernels/test_sinkhorn_simple.py
@@ -8,11 +8,6 @@ sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir))
 from utils import parse_model_args, train, inference, save_model  # noqa
 from time import time
 
-# Use `--hb` to run in HammerBlade mode. Otherwise, we run all native.
-HB = '--hb' in sys.argv
-if HB:
-    torch.hammerblade.init()
-
 # Kernel parameters.
 N_FRACTION = 16 # use N_DOCS/N_FRACTION of the data
 N_DOCS = int(4096 / N_FRACTION)
@@ -116,6 +111,11 @@ def load_data():
 
 
 def sinkhorn_test():
+    # Use `--hb` to run in HammerBlade mode. Otherwise, we run all native.
+    HB = '--hb' in sys.argv
+    if HB:
+        torch.hammerblade.init()
+
     # import json
     # with open('sinkhorn_wmd.json',) as route:
     #     data = json.load(route)
@@ -127,7 +127,8 @@ def sinkhorn_test():
 
     print(torch.hammerblade.profiler.stats())
     print("done")
-    print("Multiply sddtmm, dstmmt, and dstmm times by ", N_FRACTION, " for true time on real dataset.")
+    print("Multiply sddtmm, dstmmt, and dstmm times by",
+          N_FRACTION, "for true time on real dataset.")
 
 
 if __name__ == '__main__':

--- a/hammerblade/torch/tests/sinkhorn_tests/sinkhorn_app/profiling_kernels/test_sinkhorn_simple.py
+++ b/hammerblade/torch/tests/sinkhorn_tests/sinkhorn_app/profiling_kernels/test_sinkhorn_simple.py
@@ -1,6 +1,5 @@
 import numpy
 import scipy.sparse
-from scipy.spatial.distance import cdist
 import os
 import sys
 import torch
@@ -27,6 +26,8 @@ DATA_VECS = os.path.join(DATA_DIR, 'cache-vecs.npy')
 
 
 def swmd_torch(r, cT, vecs, niters):
+    """The actual Sinkhorn WMD kernel.
+    """
     # I=(r > 0)
     sel = r > 0
 
@@ -86,6 +87,8 @@ def swmd_torch(r, cT, vecs, niters):
 
 
 def load_data():
+    """Load data for the Sinkhorn WMD kernel.
+    """
     # Load data.
     vecs = numpy.load(DATA_VECS)
     mat = scipy.sparse.load_npz(DATA_MAT)

--- a/hammerblade/torch/tests/sinkhorn_tests/sinkhorn_app/profiling_kernels/test_sinkhorn_simple.py
+++ b/hammerblade/torch/tests/sinkhorn_tests/sinkhorn_app/profiling_kernels/test_sinkhorn_simple.py
@@ -1,0 +1,120 @@
+import numpy
+import scipy.sparse
+from scipy.spatial.distance import cdist
+import os
+import sys
+import torch
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir))
+from utils import parse_model_args, train, inference, save_model  # noqa
+from time import time
+
+torch.hammerblade.init()
+
+# import json
+# with open('sinkhorn_wmd.json',) as route:
+#     data = json.load(route)
+
+# Kernel parameters.
+N_FRACTION = 16 # use N_DOCS/N_FRACTION of the data
+N_DOCS = int(4096 / N_FRACTION)
+QUERY_IDX = 100
+LAMBDA = 1
+
+# Data files. (Ask Adrian for these.)
+DATA_DIR = os.path.join(
+    os.path.dirname(__file__),
+    '..',
+    'data',
+)
+DATA_MAT = os.path.join(DATA_DIR, 'cache-mat.npz')
+DATA_VECS = os.path.join(DATA_DIR, 'cache-vecs.npy')
+
+
+def swmd_torch(r, cT, vecs, niters):
+    # I=(r > 0)
+    sel = r > 0
+
+    # r=r(I)
+    r = r[sel].reshape(-1, 1)
+
+    # M=M(I,:)
+    M = torch.cdist(vecs[sel], vecs)
+
+    # x=ones(length(r), size(c,2)) / length(r)
+    a_dim = r.shape[0]
+    b_nobs = cT.shape[0]
+    xT = torch.ones((b_nobs, a_dim)) / a_dim
+
+    # K=exp(-lambda * M)
+    K = torch.exp(- M * LAMBDA)
+    K_div_r = K / r
+    K_T = K.T
+
+    # BEGIN PROFILING HERE
+    start_time = time()
+    # torch.hammerblade.profiler.route.set_route_from_json(data)
+    torch.hammerblade.profiler.enable()
+
+    for it in range(niters):
+        print('starting iteration {}'.format(it))
+
+        uT = 1.0 / xT
+
+        # Interesting property: sddtmmt(a,b,c) = sddtmm(a.T,c,b)
+        # Compute `c * 1/(K_T @ u)` using a hand-rolled SDDMM.
+        # v = c * (1.0 / _sddmm(c, K_T, u))
+        # v = c * (1.0 / torch.sddtmm(c, K_T, uT)
+        # vT = cT * torch.sddtmm(cT, uT, K_T).sparse_reciprocal()
+        
+        # NOTE: NEED TO ADD RECIPROCAL
+        vT = cT * torch.sddtmm(cT, uT, K_T)
+        
+        # custom dstmm.t():
+        # x = _dsmp(K_div_r, v)
+        # x = torch.dstmm(K_div_r, vT)
+        xT = torch.dstmmt(K_div_r, vT)
+
+    out = (uT.t() * torch.dstmm(K * M, vT)).sum(axis=0)
+    
+    # out = (uT * (vT @ (K_T * M.t())).sum(axis=1) 
+    #Note: M is huge compared to uT, so use the sum(axis=0) instead of sum(axis=1) line
+
+    # END PROFILING HERE
+    torch.hammerblade.profiler.disable()
+    end_time = time()
+    elapsed = end_time - start_time
+    print("elapsed:", elapsed)
+    print("elapsed * 16:", elapsed * 16)
+
+    return out
+
+
+# Load data.
+vecs = numpy.load(DATA_VECS)
+mat = scipy.sparse.load_npz(DATA_MAT)
+print("vecs size:", vecs.shape)
+mat = mat[:, :N_DOCS]  # Use a subset of the data.
+print("mat shape:", mat.shape)
+# The query vector.
+r = numpy.asarray(mat[:, QUERY_IDX].todense()).squeeze()
+
+# mat could theoretically be stored as its transpose, so don't count 
+matT = mat.T
+
+# Convert arrays to PyTorch tensors.
+r = torch.FloatTensor(r)
+cT_coo = matT.tocoo()
+cT = torch.sparse.FloatTensor(
+    torch.LongTensor(numpy.vstack((cT_coo.row, cT_coo.col))),
+    torch.FloatTensor(cT_coo.data),
+    torch.Size(cT_coo.shape),
+)
+
+vecs = torch.FloatTensor(vecs)
+
+scores = swmd_torch(r, cT, vecs, niters=1)
+
+print(torch.hammerblade.profiler.stats())
+print("done")
+print("Multiply sddtmm, dstmmt, and dstmm times by ", N_FRACTION, " for true time on real dataset.")

--- a/hammerblade/torch/tests/sinkhorn_tests/sinkhorn_app/profiling_kernels/test_sinkhorn_simple.py
+++ b/hammerblade/torch/tests/sinkhorn_tests/sinkhorn_app/profiling_kernels/test_sinkhorn_simple.py
@@ -10,9 +10,9 @@ from utils import parse_model_args, train, inference, save_model  # noqa
 from time import time
 
 # Kernel parameters.
-N_FRACTION = 16 # use N_DOCS/N_FRACTION of the data
+N_FRACTION = 16 * 16  # use N_DOCS/N_FRACTION of the data
 N_DOCS = int(4096 / N_FRACTION)
-QUERY_IDX = 100
+QUERY_IDX = 5  # Was 100; lowered to allow even smaller runs.
 LAMBDA = 1
 
 # Data files. (Ask Adrian for these.)


### PR DESCRIPTION
This is a simple version of the Sinkhorn script I hacked together to try running _the entire thing_ on HB cosim, instead of doing the multi-step process that attempts to run individual kernels on HB one at a time. Still not sure how to get real statistics out of the HB side.

This script supports a `--hb` flag that tells it whether to run in cosim, so it can run in two modes:

* `python test_sinkhorn_simple.py` for normal, all-native execution
* `pycosim test_sinkhorn_simple.py --hb` for cosim, HB-laden execution of the three key kernels